### PR TITLE
fix: ci scope for push on all branchs except main and dev fixed

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,7 +2,7 @@ name: Tests and Coverage
 
 on:
   push:
-    branches: [ main, develop, feat/** ]
+    branches: [ main ]
   pull_request:
     branches: [ main, develop ]
 

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -1,0 +1,31 @@
+name: Push Unit Tests (no coverage)
+
+on:
+  push:
+    branches-ignore: [ main, develop ]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PNPM
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.14.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit tests (API + Web)
+        run: pnpm test
+


### PR DESCRIPTION
This pull request updates the CI workflow configuration to better separate test coverage and unit test runs based on branch targeting. The main changes are a refinement of which branches trigger coverage checks and the introduction of a new workflow for running unit tests on feature branches.

**CI Workflow Restructuring:**

* Renamed `.github/workflows/tests.yml` to `.github/workflows/ci-pr.yml` and limited coverage checks to only run on pushes to the `main` branch, while pull requests continue to trigger checks for both `main` and `develop` branches.

**New Unit Test Workflow for Feature Branches:**

* Added `.github/workflows/ci-push.yml` to run unit tests (without coverage) on pushes to all branches except `main` and `develop`, ensuring feature branches are tested before merging.