### PR TITLE
fix(security): jwt token role payloads

### DIFF
--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -16,6 +16,9 @@ describe('AuthService', () => {
     findByEmail: jest.fn(),
     validatePassword: jest.fn(),
     findPrimaryRole: jest.fn().mockResolvedValue(null),
+    findRolesAndClinics: jest
+      .fn()
+      .mockResolvedValue({ roles: [], clinicIds: [] }),
   };
 
   const mockJwtService = {

--- a/apps/api/src/auth/strategies/jwt.strategy.spec.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.spec.ts
@@ -28,13 +28,17 @@ describe('JwtStrategy', () => {
         return 'A B';
       },
     } as any);
-    usersService.findPrimaryRole.mockResolvedValue('VET');
 
     const strat = new JwtStrategy(
       authService as unknown as AuthService,
       usersService as unknown as UsersService,
     );
-    const res = await strat.validate({ sub: 'u1', email: 'a@b.c' } as any);
+    const res = await strat.validate({
+      sub: 'u1',
+      email: 'a@b.c',
+      roles: ['VET'],
+      clinicIds: ['c1'],
+    } as any);
     expect(res).toEqual({
       id: 'u1',
       email: 'a@b.c',
@@ -42,7 +46,7 @@ describe('JwtStrategy', () => {
       lastName: 'B',
       role: 'VET',
       roles: ['VET'],
-      clinicIds: [],
+      clinicIds: ['c1'],
     });
   });
   it('returns null when user invalid', async () => {

--- a/apps/api/src/auth/strategies/jwt.strategy.ts
+++ b/apps/api/src/auth/strategies/jwt.strategy.ts
@@ -8,6 +8,8 @@ import type { UserRole } from '../guards/roles.guard';
 interface JwtPayload {
   sub: string;
   email: string;
+  roles: UserRole[];
+  clinicIds: string[];
 }
 
 interface AuthenticatedUser {
@@ -39,18 +41,16 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
       return null;
     }
 
-    // Load primary role and all roles (MVP: first match as primary, plus list)
-    const primaryRole =
-      (await this.usersService.findPrimaryRole(user.id)) || 'OWNER';
-    // For future: include clinicIds if needed; left empty for now
+    const primaryRole = payload.roles?.[0] || 'OWNER';
+
     const result: AuthenticatedUser = {
       id: user.id,
       email: user.email,
       firstName: user.firstName,
       lastName: user.lastName,
       role: primaryRole,
-      roles: [primaryRole],
-      clinicIds: [],
+      roles: payload.roles || [],
+      clinicIds: payload.clinicIds || [],
     };
     return result;
   }

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -65,6 +65,17 @@ export class UsersService {
     return link?.role ?? null;
   }
 
+  async findRolesAndClinics(
+    userId: string,
+  ): Promise<{ roles: UserClinicRole['role'][]; clinicIds: string[] }> {
+    const links = await this.userClinicRoleRepository.find({
+      where: { userId },
+    });
+    const roles = links.map((link) => link.role);
+    const clinicIds = links.map((link) => link.clinicId);
+    return { roles, clinicIds };
+  }
+
   async validatePassword(user: User, password: string): Promise<boolean> {
     return bcrypt.compare(password, user.password);
   }


### PR DESCRIPTION
This pull request updates the authentication flow to include user roles and associated clinic IDs in the JWT token and throughout the authentication process. The changes ensure that both roles and clinic information are available for frontend RBAC and backend authorization, and refactor related service methods and tests to support these additions.

**Authentication payload enhancements:**

* The JWT token now includes both `roles` and `clinicIds` for the authenticated user, allowing for more granular role-based access control and clinic-specific authorization. (`apps/api/src/auth/auth.service.ts` [[1]](diffhunk://#diff-7e9ac17d7e6417f73125395406cff59ad6eee28fab0bcca2993d72e2e439fae6L37-R37) [[2]](diffhunk://#diff-7e9ac17d7e6417f73125395406cff59ad6eee28fab0bcca2993d72e2e439fae6R76-R85) [[3]](diffhunk://#diff-7e9ac17d7e6417f73125395406cff59ad6eee28fab0bcca2993d72e2e439fae6L105-R124); `apps/api/src/auth/strategies/jwt.strategy.ts` [[4]](diffhunk://#diff-f41e18e2a37c412db0bd91677745717d565ae50377a2d12a7448c88445358a24R11-R12) [[5]](diffhunk://#diff-f41e18e2a37c412db0bd91677745717d565ae50377a2d12a7448c88445358a24L42-R53)

**Service and method updates:**

* Added a new `findRolesAndClinics` method to `UsersService` to fetch all roles and clinic IDs associated with a user, and integrated this method into the authentication flow. (`apps/api/src/users/users.service.ts` [[1]](diffhunk://#diff-958492a8319449997238b11baa4159c77356a08ea2ff510668455f94432e65e7R68-R78); `apps/api/src/auth/auth.service.ts` [[2]](diffhunk://#diff-7e9ac17d7e6417f73125395406cff59ad6eee28fab0bcca2993d72e2e439fae6R76-R85) [[3]](diffhunk://#diff-29926a985496e40543ae98ef95c67e8034d9eeac3b3cd7a810c50daf5cb1ca3aR19-R21)
* Refactored the `generateToken` method in `AuthService` to accept and encode `roles` and `clinicIds` in the JWT payload. (`apps/api/src/auth/auth.service.ts` [apps/api/src/auth/auth.service.tsL105-R124](diffhunk://#diff-7e9ac17d7e6417f73125395406cff59ad6eee28fab0bcca2993d72e2e439fae6L105-R124))

**Test updates:**

* Updated and added test mocks and expectations to reflect the new roles and clinicIds logic in both AuthService and JwtStrategy tests. (`apps/api/src/auth/auth.service.spec.ts` [[1]](diffhunk://#diff-29926a985496e40543ae98ef95c67e8034d9eeac3b3cd7a810c50daf5cb1ca3aR19-R21); `apps/api/src/auth/strategies/jwt.strategy.spec.ts` [[2]](diffhunk://#diff-8ded607e642ca7cb9cd2c2f31e311964ab8bc483b238832c4fc047085161e07dL31-R49)

**Role resolution changes:**

* The primary role is now resolved directly from the JWT payload’s roles array, simplifying the strategy logic and reducing unnecessary database calls. (`apps/api/src/auth/strategies/jwt.strategy.ts` [apps/api/src/auth/strategies/jwt.strategy.tsL42-R53](diffhunk://#diff-f41e18e2a37c412db0bd91677745717d565ae50377a2d12a7448c88445358a24L42-R53))