### PR TITLE
fix(railway): fix railway proxy

### DIFF
--- a/apps/web/src/services/http.service.ts
+++ b/apps/web/src/services/http.service.ts
@@ -1,7 +1,7 @@
 import { authService } from './auth.service';
 
 class HttpService {
-  private baseUrl = '/api';
+  private baseUrl = ((import.meta as unknown as ImportMeta)?.env?.VITE_API_BASE_URL || '/api');
 
   private async request<T>(
     endpoint: string,


### PR DESCRIPTION
This pull request updates the way the base API URL is determined in the `HttpService` to support environment-based configuration. This allows the service to dynamically use the value of `VITE_API_BASE_URL` if it is set, improving flexibility for different deployment environments.

* Updated the `baseUrl` initialization in `http.service.ts` to use `VITE_API_BASE_URL` from environment variables, falling back to `/api` if not set.