### PR TITLE
fix(admin): webmaster was able to delete his own account

### DIFF
--- a/apps/api/src/admin/admin.controller.spec.ts
+++ b/apps/api/src/admin/admin.controller.spec.ts
@@ -113,9 +113,11 @@ describe('AdminController', () => {
     it('should remove a user successfully', async () => {
       service.removeUser.mockResolvedValue();
 
-      await controller.removeUser('user-1');
+      // pass a mock request with a user id (webmaster) different from target
+      const mockReq = { user: { id: 'admin-1' } } as any;
+      await controller.removeUser('user-1', mockReq);
 
-      expect(service.removeUser).toHaveBeenCalledWith('user-1');
+      expect(service.removeUser).toHaveBeenCalledWith('admin-1', 'user-1');
     });
   });
 

--- a/apps/api/src/admin/admin.controller.ts
+++ b/apps/api/src/admin/admin.controller.ts
@@ -9,6 +9,7 @@ import {
   Param,
   Patch,
   Delete,
+  Req,
 } from '@nestjs/common';
 import { Roles } from '../auth/decorators/roles.decorator';
 import { RolesGuard } from '../auth/guards/roles.guard';
@@ -159,8 +160,8 @@ export class AdminController {
   @ApiNotFoundResponse({
     description: 'Utilisateur non trouvé',
   })
-  removeUser(@Param('id') id: string) {
-    return this.adminService.removeUser(id);
+  removeUser(@Param('id') id: string, @Req() req: any) {
+    return this.adminService.removeUser(req.user?.id, id);
   }
 
   @Patch('clinics/:id')

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -116,15 +116,9 @@ export class AdminService {
     }
 
     // Prevent deleting another webmaster (only if we can resolve role)
-    const maybeFindPrimaryRole: any = (this.usersService as any)
-      .findPrimaryRole;
-    if (typeof maybeFindPrimaryRole === 'function') {
-      const targetPrimaryRole = await (
-        maybeFindPrimaryRole as (userId: string) => Promise<string>
-      ).call(this.usersService, targetUserId);
-      if (targetPrimaryRole === 'WEBMASTER') {
-        throw new ForbiddenException('You cannot delete a webmaster');
-      }
+    const targetPrimaryRole = await this.usersService.findPrimaryRole(targetUserId);
+    if (targetPrimaryRole === 'WEBMASTER') {
+      throw new ForbiddenException('You cannot delete a webmaster');
     }
 
     return this.usersService.remove(targetUserId);

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -116,9 +116,20 @@ export class AdminService {
     }
 
     // Prevent deleting another webmaster (only if we can resolve role)
-    const targetPrimaryRole = await this.usersService.findPrimaryRole(targetUserId);
-    if (targetPrimaryRole === 'WEBMASTER') {
-      throw new ForbiddenException('You cannot delete a webmaster');
+    type WithFindPrimaryRole = {
+      findPrimaryRole: (userId: string) => Promise<UserRole | null>;
+    };
+    const hasFindPrimaryRole = (
+      svc: unknown,
+    ): svc is UsersService & WithFindPrimaryRole =>
+      typeof (svc as WithFindPrimaryRole).findPrimaryRole === 'function';
+
+    if (hasFindPrimaryRole(this.usersService)) {
+      const targetPrimaryRole =
+        await this.usersService.findPrimaryRole(targetUserId);
+      if (targetPrimaryRole === 'WEBMASTER') {
+        throw new ForbiddenException('You cannot delete a webmaster');
+      }
     }
 
     return this.usersService.remove(targetUserId);

--- a/apps/api/src/admin/admin.service.ts
+++ b/apps/api/src/admin/admin.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   ConflictException,
   BadRequestException,
+  ForbiddenException,
 } from '@nestjs/common';
 import { UsersService } from '../users/users.service';
 import { ClinicsService } from '../clinics/clinics.service';
@@ -99,8 +100,34 @@ export class AdminService {
     return { ...result, fullName: `${result.firstName} ${result.lastName}` };
   }
 
-  async removeUser(userId: string): Promise<void> {
-    return this.usersService.remove(userId);
+  // Overloaded signatures for backward compatibility
+  async removeUser(targetUserId: string): Promise<void>;
+  async removeUser(
+    requesterId: string | undefined,
+    targetUserId: string,
+  ): Promise<void>;
+  async removeUser(arg1: string | undefined, arg2?: string): Promise<void> {
+    const requesterId = arg2 ? arg1 : undefined;
+    const targetUserId = arg2 ? arg2 : (arg1 as string);
+
+    // Do not allow self-deletion (only if requesterId is provided)
+    if (requesterId && requesterId === targetUserId) {
+      throw new ForbiddenException('You cannot delete your own account');
+    }
+
+    // Prevent deleting another webmaster (only if we can resolve role)
+    const maybeFindPrimaryRole: any = (this.usersService as any)
+      .findPrimaryRole;
+    if (typeof maybeFindPrimaryRole === 'function') {
+      const targetPrimaryRole = await (
+        maybeFindPrimaryRole as (userId: string) => Promise<string>
+      ).call(this.usersService, targetUserId);
+      if (targetPrimaryRole === 'WEBMASTER') {
+        throw new ForbiddenException('You cannot delete a webmaster');
+      }
+    }
+
+    return this.usersService.remove(targetUserId);
   }
 
   async updateClinic(

--- a/apps/web/src/pages/admin/AdminUsers.tsx
+++ b/apps/web/src/pages/admin/AdminUsers.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { adminService } from '../../services/admin.service';
 import type { AdminUserDto } from '../../services/admin.service';
+import { useAuth } from '../../hooks/useAuth';
 
 // Role configuration with colors and icons
 const roleConfig = {
@@ -13,6 +14,7 @@ const roleConfig = {
 };
 
 export function AdminUsers() {
+  const { user } = useAuth();
   const [users, setUsers] = useState<AdminUserDto[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -38,6 +40,19 @@ export function AdminUsers() {
   }, []);
 
   const handleDelete = async (userId: string) => {
+    const target = users.find((u) => u.id === userId);
+    const isSelf = user?.id === userId;
+    const isTargetWebmaster = (target?.role || '').toUpperCase() === 'WEBMASTER';
+
+    if (isSelf || isTargetWebmaster) {
+      setError(
+        isSelf
+          ? 'Vous ne pouvez pas supprimer votre propre compte.'
+          : 'Vous ne pouvez pas supprimer un compte webmaster.',
+      );
+      return;
+    }
+
     if (window.confirm('Êtes-vous sûr de vouloir supprimer cet utilisateur ?')) {
       try {
         await adminService.deleteUser(userId);
@@ -72,7 +87,7 @@ export function AdminUsers() {
         </Link>
       </div>
       {loading && <p>Loading...</p>}
-      {error && <p className="text-red-500">{error}</p>}
+      {error && <p className="text-red-500" role="alert">{error}</p>}
       <div className="overflow-x-auto">
         <table className="min-w-full bg-white">
           <thead>
@@ -87,31 +102,51 @@ export function AdminUsers() {
           </thead>
           <tbody>
             {users && users.length > 0 ? (
-              users.map((user) => (
-                <tr key={user.id}>
-                  <td className="py-2 px-4 border-b font-medium">{user.email}</td>
-                  <td className="py-2 px-4 border-b">{user.firstName} {user.lastName}</td>
-                  <td className="py-2 px-4 border-b">
-                    {getRoleBadge(user.role || 'OWNER')}
-                  </td>
-                  <td className="py-2 px-4 border-b">
-                    <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                      user.isEmailVerified 
-                        ? 'bg-green-100 text-green-800' 
-                        : 'bg-yellow-100 text-yellow-800'
-                    }`}>
-                      {user.isEmailVerified ? '✅ Oui' : '⏳ Non'}
-                    </span>
-                  </td>
-                  <td className="py-2 px-4 border-b text-sm text-gray-600">
-                    {new Date(user.createdAt).toLocaleDateString()}
-                  </td>
-                  <td className="py-2 px-4 border-b space-x-2">
-                    <Link to={`/admin/users/${user.id}/edit`} className="text-green-600 hover:underline">Modifier</Link>
-                    <button onClick={() => handleDelete(user.id)} className="text-red-600 hover:underline">Supprimer</button>
-                  </td>
-                </tr>
-              ))
+              users.map((u) => {
+                const isSelf = user?.id === u.id;
+                const isWebmaster = (u.role || '').toUpperCase() === 'WEBMASTER';
+                const canDelete = !isSelf && !isWebmaster;
+                return (
+                  <tr key={u.id}>
+                    <td className="py-2 px-4 border-b font-medium">{u.email}</td>
+                    <td className="py-2 px-4 border-b">{u.firstName} {u.lastName}</td>
+                    <td className="py-2 px-4 border-b">
+                      {getRoleBadge(u.role || 'OWNER')}
+                    </td>
+                    <td className="py-2 px-4 border-b">
+                      <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                        u.isEmailVerified 
+                          ? 'bg-green-100 text-green-800' 
+                          : 'bg-yellow-100 text-yellow-800'
+                      }`}>
+                        {u.isEmailVerified ? '✅ Oui' : '⏳ Non'}
+                      </span>
+                    </td>
+                    <td className="py-2 px-4 border-b text-sm text-gray-600">
+                      {new Date(u.createdAt).toLocaleDateString()}
+                    </td>
+                    <td className="py-2 px-4 border-b space-x-2">
+                      <Link to={`/admin/users/${u.id}/edit`} className="text-green-600 hover:underline">Modifier</Link>
+                      <button
+                        onClick={() => handleDelete(u.id)}
+                        className={`hover:underline ${canDelete ? 'text-red-600' : 'text-gray-400 cursor-not-allowed'}`}
+                        disabled={!canDelete}
+                        aria-disabled={!canDelete}
+                        aria-label={canDelete ? 'Supprimer' : 'Suppression désactivée'}
+                        title={
+                          isSelf
+                            ? 'Vous ne pouvez pas supprimer votre propre compte'
+                            : isWebmaster
+                              ? 'Vous ne pouvez pas supprimer un webmaster'
+                              : 'Supprimer'
+                        }
+                      >
+                        Supprimer
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })
             ) : (
               <tr>
                 <td colSpan={6} className="py-4 px-4 text-center text-gray-500">


### PR DESCRIPTION
This pull request introduces important security and UX improvements to the user deletion feature in the admin panel. The main changes ensure that users cannot delete their own accounts or delete accounts with the "WEBMASTER" role, both in the backend API and in the frontend UI. The backend now enforces these restrictions and provides appropriate error handling, while the frontend disables the delete button and displays clear error messages to users.

**Backend: User Deletion Restrictions and API Changes**
- The `AdminService.removeUser` method now prevents users from deleting their own accounts and from deleting users with the "WEBMASTER" role. It throws a `ForbiddenException` in these cases. The method also supports both the old and new signatures for backward compatibility.
- The `AdminController.removeUser` method now receives the request object to identify the requester and passes both the requester and target user IDs to the service, updating both the controller and its unit test accordingly. [[1]](diffhunk://#diff-a46f5dbe3d6f3e80691fc954822826b7c14ab17f64bb26e52205b9be875d5145L162-R164) [[2]](diffhunk://#diff-a46f5dbe3d6f3e80691fc954822826b7c14ab17f64bb26e52205b9be875d5145R12) [[3]](diffhunk://#diff-47a3f32dc3dbad165fe64f7c56f9d5f85a5da6ac8b82f643272c17ee325a3f8cL116-R120) [[4]](diffhunk://#diff-91962769643bab333f80b6b305b83b0c274fb5193b3cca6037a79d5e9fc93b79R5)

**Frontend: UI/UX Improvements and Safeguards**
- The admin users page now uses the authenticated user's information to determine if the delete action should be available. The delete button is disabled and visually muted for self-deletion or "WEBMASTER" users, with appropriate tooltips and accessibility attributes.
- The frontend checks for self-deletion and "WEBMASTER" role before attempting deletion, displaying user-friendly error messages if the action is not allowed. [[1]](diffhunk://#diff-1330e555e82618300930e0316d8f1bfd078fc68a1ce1cbfe9e5ce2dd904146dfR43-R55) [[2]](diffhunk://#diff-1330e555e82618300930e0316d8f1bfd078fc68a1ce1cbfe9e5ce2dd904146dfL75-R90)
- The `useAuth` hook is now used to access the current user's information in the admin users page. [[1]](diffhunk://#diff-1330e555e82618300930e0316d8f1bfd078fc68a1ce1cbfe9e5ce2dd904146dfR5) [[2]](diffhunk://#diff-1330e555e82618300930e0316d8f1bfd078fc68a1ce1cbfe9e5ce2dd904146dfR17)