### PR TITLE
Refactor/tag details

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -15,6 +15,7 @@ import { VetAgenda } from './pages/VetAgenda';
 import { OwnerAppointments } from './pages/owner/OwnerAppointments';
 import { OwnerAnimals } from './pages/owner/OwnerAnimals';
 import { VetReminders } from './pages/vet/VetReminders';
+import { VetAnimals } from './pages/vet/VetAnimals';
 import { AdminUsers } from './pages/admin/AdminUsers';
 import { AdminClinics } from './pages/admin/AdminClinics';
 import { AdminCreateClinic } from './pages/admin/AdminCreateClinic';
@@ -156,6 +157,11 @@ function App() {
             <Route path="/vet/reminders" element={
               <ProtectedRoute anyOfRoles={['VET', 'ADMIN_CLINIC']}>
                 <VetReminders />
+              </ProtectedRoute>
+            } />
+            <Route path="/vet/animals" element={
+              <ProtectedRoute requiredRole="VET">
+                <VetAnimals />
               </ProtectedRoute>
             } />
             <Route path="/admin/users" element={

--- a/apps/web/src/components/AnimalDetailsModal.tsx
+++ b/apps/web/src/components/AnimalDetailsModal.tsx
@@ -49,6 +49,7 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 	const [error, setError] = useState<string | null>(null);
 	const [history, setHistory] = useState<AnimalHistoryDto | null>(null);
 	const [documents, setDocuments] = useState<Record<string, { id: string; filename: string }[]>>({});
+	const [expanded, setExpanded] = useState<Record<string, boolean>>({});
 
 	useEffect(() => {
 		let isCancelled = false;
@@ -160,9 +161,46 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 						) : (
 							<ul className="text-sm space-y-2">
 								{upcomingAppointments.map((a) => (
-									<li key={a.id} className="flex items-center justify-between">
-										<span>{formatDate(a.startsAt)}</span>
-										<span className="text-gray-600">{a.type?.label || 'RDV'} — {statusLabel(a.status)}</span>
+									<li key={a.id} className="">
+										<div className="flex items-center justify-between gap-3">
+											<span>{formatDate(a.startsAt)}</span>
+											<div className="flex items-center gap-2">
+												<span className="text-gray-600">{a.type?.label || 'RDV'} — {statusLabel(a.status)}</span>
+												<button
+													type="button"
+													className="text-xs px-2 py-1 rounded border hover:bg-gray-50"
+													onClick={() => setExpanded((prev) => ({ ...prev, [a.id]: !prev[a.id] }))}
+												>
+													{expanded[a.id] ? 'Masquer' : 'Détails'}
+												</button>
+											</div>
+										</div>
+										{expanded[a.id] ? (
+											<div className="mt-2 grid grid-cols-1 md:grid-cols-2 gap-2">
+												{a.notes ? (
+													<div className="bg-yellow-50 border border-yellow-200 rounded p-2">
+														<div className="text-xs font-medium text-yellow-800">Notes internes</div>
+														<p className="text-sm text-yellow-900 whitespace-pre-wrap">{a.notes}</p>
+													</div>
+												) : null}
+												{a.report ? (
+													<div className="bg-green-50 border border-green-200 rounded p-2">
+														<div className="text-xs font-medium text-green-800">Compte-rendu</div>
+														<p className="text-sm text-green-900 whitespace-pre-wrap">{a.report}</p>
+													</div>
+												) : null}
+												{documents[a.id] && documents[a.id].length > 0 ? (
+													<div className="bg-gray-50 border border-gray-200 rounded p-2 md:col-span-2">
+														<div className="text-xs font-medium text-gray-700">Documents</div>
+														<ul className="mt-1 text-sm list-disc pl-5">
+															{documents[a.id].map((doc) => (
+																<li key={doc.id}>📄 {doc.filename}</li>
+															))}
+														</ul>
+													</div>
+												) : null}
+											</div>
+										) : null}
 									</li>
 								))}
 							</ul>
@@ -177,11 +215,45 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 							<ul className="text-sm space-y-3">
 								{recentReports.map((a) => (
 									<li key={a.id} className="border-b pb-2 last:border-b-0">
-										<div className="flex items-center justify-between">
+										<div className="flex items-center justify-between gap-3">
 											<span className="text-gray-500">{formatDate(a.startsAt)}</span>
-											<span className="text-gray-600">{a.type?.label || 'RDV'} — {statusLabel(a.status)}</span>
+											<div className="flex items-center gap-2">
+												<span className="text-gray-600">{a.type?.label || 'RDV'} — {statusLabel(a.status)}</span>
+												<button
+													type="button"
+													className="text-xs px-2 py-1 rounded border hover:bg-gray-50"
+													onClick={() => setExpanded((prev) => ({ ...prev, [a.id]: !prev[a.id] }))}
+												>
+													{expanded[a.id] ? 'Masquer' : 'Détails'}
+												</button>
+											</div>
 										</div>
-										{a.report ? <p className="mt-1">Rapport: {a.report}</p> : null}
+										{expanded[a.id] ? (
+											<div className="mt-2 grid grid-cols-1 md:grid-cols-2 gap-2">
+												{a.notes ? (
+													<div className="bg-yellow-50 border border-yellow-200 rounded p-2">
+														<div className="text-xs font-medium text-yellow-800">Notes internes</div>
+														<p className="text-sm text-yellow-900 whitespace-pre-wrap">{a.notes}</p>
+													</div>
+												) : null}
+												{a.report ? (
+													<div className="bg-green-50 border border-green-200 rounded p-2">
+														<div className="text-xs font-medium text-green-800">Compte-rendu</div>
+														<p className="text-sm text-green-900 whitespace-pre-wrap">{a.report}</p>
+													</div>
+												) : null}
+												{documents[a.id] && documents[a.id].length > 0 ? (
+													<div className="bg-gray-50 border border-gray-200 rounded p-2 md:col-span-2">
+														<div className="text-xs font-medium text-gray-700">Documents</div>
+														<ul className="mt-1 text-sm list-disc pl-5">
+															{documents[a.id].map((doc) => (
+																<li key={doc.id}>📄 {doc.filename}</li>
+															))}
+														</ul>
+													</div>
+												) : null}
+											</div>
+										) : null}
 									</li>
 								))}
 							</ul>

--- a/apps/web/src/components/AnimalDetailsModal.tsx
+++ b/apps/web/src/components/AnimalDetailsModal.tsx
@@ -4,6 +4,17 @@ import { animalsService } from '../services/animals.service';
 import { documentsService } from '../services/documents.service';
 import { httpService } from '../services/http.service';
 
+const STATUS_LABELS: Record<string, string> = {
+    PENDING: 'En attente',
+    CONFIRMED: 'Confirmé',
+    REJECTED: 'Refusé',
+    CANCELLED: 'Annulé',
+    COMPLETED: 'Terminé',
+};
+function statusLabel(status: string): string {
+    return STATUS_LABELS[status] ?? status;
+}
+
 interface AnimalDetailsModalProps {
 	isOpen: boolean;
 	onClose: () => void;
@@ -151,7 +162,7 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 								{upcomingAppointments.map((a) => (
 									<li key={a.id} className="flex items-center justify-between">
 										<span>{formatDate(a.startsAt)}</span>
-										<span className="text-gray-600">{a.type?.label || 'RDV'} — {a.status}</span>
+										<span className="text-gray-600">{a.type?.label || 'RDV'} — {statusLabel(a.status)}</span>
 									</li>
 								))}
 							</ul>
@@ -168,7 +179,7 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 									<li key={a.id} className="border-b pb-2 last:border-b-0">
 										<div className="flex items-center justify-between">
 											<span className="text-gray-500">{formatDate(a.startsAt)}</span>
-											<span className="text-gray-600">{a.type?.label || 'RDV'} — {a.status}</span>
+											<span className="text-gray-600">{a.type?.label || 'RDV'} — {statusLabel(a.status)}</span>
 										</div>
 										{a.report ? <p className="mt-1">Rapport: {a.report}</p> : null}
 									</li>

--- a/apps/web/src/components/__tests__/AnimalDetailsModal.test.tsx
+++ b/apps/web/src/components/__tests__/AnimalDetailsModal.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AnimalDetailsModal } from '../AnimalDetailsModal';
 import { animalsService } from '../../services/animals.service';
@@ -110,12 +110,20 @@ describe('AnimalDetailsModal', () => {
     });
   });
 
-  it('displays recent reports', async () => {
+  it('displays recent reports inside expandable details', async () => {
     render(<AnimalDetailsModal {...defaultProps} />);
 
     await waitFor(() => {
       expect(screen.getByText('Rapports récents')).toBeInTheDocument();
-      expect(screen.getByText('Rapport: Animal en bonne santé')).toBeInTheDocument();
+    });
+
+    // Expand any "Détails" sections to reveal report content
+    const detailButtons = screen.getAllByRole('button', { name: 'Détails' });
+    detailButtons.forEach(btn => fireEvent.click(btn));
+
+    await waitFor(() => {
+      // Report content should now be visible
+      expect(screen.getByText('Animal en bonne santé')).toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/RolePanel.tsx
+++ b/apps/web/src/pages/RolePanel.tsx
@@ -23,6 +23,16 @@ const cards = [
 		),
 	},
 	{
+		key: 'VET_ANIMALS',
+		roles: ['VET'],
+		to: '/vet/animals',
+		title: 'Mes patients',
+		desc: 'Liste des animaux suivis et leurs historiques',
+		icon: (
+			<span className="text-3xl" aria-hidden>🐾</span>
+		),
+	},
+	{
 		key: 'VET_REMINDERS',
 		roles: ['VET', 'ADMIN_CLINIC'],
 		to: '/vet/reminders',

--- a/apps/web/src/pages/VetAgenda.tsx
+++ b/apps/web/src/pages/VetAgenda.tsx
@@ -526,6 +526,19 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
     }
   };
 
+  const handleConfirmPending = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      await appointmentsService.confirmAppointment(item.id);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to confirm appointment');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleFileUpload = async () => {
     if (!file) return;
     setUploading(true);
@@ -604,7 +617,26 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
               <div className="border rounded p-3 md:col-span-2">
                 <div className="font-medium mb-1">Rendez-vous</div>
                 <div className="text-sm text-gray-700">Heure: {start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} → {end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</div>
-                <div className="text-sm text-gray-700">Statut: {statusLabel(item.status)}</div>
+                <div className="text-sm text-gray-700 flex items-center gap-2">Statut: {statusLabel(item.status)} {item.status === 'PENDING' ? (
+                  <>
+                    <button
+                      type="button"
+                      className="ml-2 text-xs px-2 py-1 rounded bg-green-600 text-white hover:bg-green-700 disabled:opacity-50"
+                      onClick={handleConfirmPending}
+                      disabled={loading}
+                    >
+                      Valider
+                    </button>
+                    <button
+                      type="button"
+                      className="text-xs px-2 py-1 rounded bg-gray-200 text-gray-600 cursor-not-allowed"
+                      title="Refus non disponible pour le moment"
+                      disabled
+                    >
+                      Refuser
+                    </button>
+                  </>
+                ) : null}</div>
                 {history ? (
                   (() => {
                     const current = history.appointments.find((a) => a.id === item.id);

--- a/apps/web/src/pages/VetAgenda.tsx
+++ b/apps/web/src/pages/VetAgenda.tsx
@@ -1,4 +1,17 @@
 import { useEffect, useMemo, useRef, useState, type JSX, useCallback } from 'react';
+const STATUS_LABELS: Record<string, string> = {
+  PENDING: 'En attente',
+  CONFIRMED: 'Confirmé',
+  REJECTED: 'Refusé',
+  CANCELLED: 'Annulé',
+  COMPLETED: 'Terminé',
+  BLOCKED: 'Bloqué',
+  NO_SHOW: 'Absent',
+  REQUESTED: 'Demandé',
+};
+function statusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status;
+}
 import { agendaService, type AgendaItem } from '../services/agenda.service';
 import { animalsService, type AnimalHistoryDto } from '../services/animals.service';
 import { clinicsService } from '../services/clinics.service';
@@ -161,7 +174,7 @@ export function VetAgenda() {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mt-4">
             {byHour.map(([hour, rows]) => (
               <div key={hour} className="border rounded p-3">
-                <div className="font-medium mb-2">{hour}h</div>
+                <div className="font-medium mb-2">{hour}</div>
                 <div className="space-y-2">
                   {rows.map((r) => (
                     <AgendaRow key={r.id} item={r} onOpenModal={() => setOpenItem(r)} />
@@ -343,7 +356,7 @@ function WeekGrid({ items, anchorDate, setOpenItem }: { items: AgendaItem[]; anc
           if (!isBlocked) {
             if (dayIndex < 0 || dayIndex > 6) return null; // outside current week
             const { start, end } = computeRowSpan(s, e);
-            const content = `${it.animal?.name || 'RDV'} — ${it.status}`;
+            const content = `${it.animal?.name || 'RDV'} — ${statusLabel(it.status)}`;
             const statusClass = it.status === 'COMPLETED'
               ? 'bg-gray-400/80 hover:bg-gray-500'
               : 'bg-blue-500/80 hover:bg-blue-600';
@@ -590,7 +603,7 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
               <div className="border rounded p-3 md:col-span-2">
                 <div className="font-medium mb-1">Rendez-vous</div>
                 <div className="text-sm text-gray-700">Heure: {start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} → {end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</div>
-                <div className="text-sm text-gray-700">Statut: {item.status}</div>
+                <div className="text-sm text-gray-700">Statut: {statusLabel(item.status)}</div>
                 <div className="mt-3">
                   <div className="font-medium">Historique de l'animal</div>
                   {loading ? <div className="text-sm text-gray-500">Chargement…</div> : null}
@@ -600,7 +613,7 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
                       {history.appointments.slice(0, 5).map((apt) => (
                         <li key={apt.id} className="flex items-center justify-between">
                           <span>{new Date(apt.startsAt).toLocaleDateString()} {new Date(apt.startsAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
-                          <span className="text-gray-600">{apt.type?.label || 'RDV'} — {apt.status}</span>
+                          <span className="text-gray-600">{apt.type?.label || 'RDV'} — {statusLabel(apt.status)}</span>
                         </li>
                       ))}
                       {history.appointments.length === 0 ? <li className="text-gray-600">Aucun historique</li> : null}
@@ -698,7 +711,7 @@ function AgendaRow({ item, onOpenModal }: { item: AgendaItem; onOpenModal: () =>
         </div>
         <div className="flex items-center gap-2">
           <span className={`text-xs px-2 py-1 rounded ${item.status === 'COMPLETED' ? 'bg-gray-200 text-gray-800' : item.status === 'CONFIRMED' ? 'bg-green-100 text-green-800' : item.status === 'PENDING' ? 'bg-yellow-100 text-yellow-800' : 'bg-gray-100 text-gray-700'}`}>
-            {item.status}
+            {statusLabel(item.status)}
           </span>
           <button className="text-blue-600 text-sm hover:underline" onClick={onOpenModal}>Détails</button>
         </div>

--- a/apps/web/src/pages/VetAgenda.tsx
+++ b/apps/web/src/pages/VetAgenda.tsx
@@ -486,6 +486,7 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
   const [documents, setDocuments] = useState<Document[]>([]);
   const [uploading, setUploading] = useState(false);
   const [file, setFile] = useState<File | null>(null);
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
   const [completionForm, setCompletionForm] = useState<CompleteAppointmentData>({
     notes: '',
     report: '',
@@ -604,16 +605,67 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
                 <div className="font-medium mb-1">Rendez-vous</div>
                 <div className="text-sm text-gray-700">Heure: {start.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} → {end.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</div>
                 <div className="text-sm text-gray-700">Statut: {statusLabel(item.status)}</div>
+                {history ? (
+                  (() => {
+                    const current = history.appointments.find((a) => a.id === item.id);
+                    if (!current) return null;
+                    return (
+                      <div className="mt-3 grid grid-cols-1 md:grid-cols-2 gap-3">
+                        {current.notes ? (
+                          <div className="bg-yellow-50 border border-yellow-200 rounded p-2">
+                            <div className="text-sm font-medium text-yellow-800">Notes internes</div>
+                            <p className="text-sm text-yellow-900 whitespace-pre-wrap">{current.notes}</p>
+                          </div>
+                        ) : null}
+                        {current.report ? (
+                          <div className="bg-green-50 border border-green-200 rounded p-2">
+                            <div className="text-sm font-medium text-green-800">Compte-rendu</div>
+                            <p className="text-sm text-green-900 whitespace-pre-wrap">{current.report}</p>
+                          </div>
+                        ) : null}
+                      </div>
+                    );
+                  })()
+                ) : null}
                 <div className="mt-3">
                   <div className="font-medium">Historique de l'animal</div>
                   {loading ? <div className="text-sm text-gray-500">Chargement…</div> : null}
                   {error ? <div className="text-sm text-red-700 bg-red-50 border border-red-200 rounded p-2">{error}</div> : null}
                   {history && (
-                    <ul className="mt-2 space-y-1 text-sm">
+                    <ul className="mt-2 space-y-2 text-sm">
                       {history.appointments.slice(0, 5).map((apt) => (
-                        <li key={apt.id} className="flex items-center justify-between">
-                          <span>{new Date(apt.startsAt).toLocaleDateString()} {new Date(apt.startsAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
-                          <span className="text-gray-600">{apt.type?.label || 'RDV'} — {statusLabel(apt.status)}</span>
+                        <li key={apt.id}>
+                          <div className="flex items-center justify-between gap-3">
+                            <span>{new Date(apt.startsAt).toLocaleDateString()} {new Date(apt.startsAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+                            <div className="flex items-center gap-2">
+                              <span className="text-gray-600">{apt.type?.label || 'RDV'} — {statusLabel(apt.status)}</span>
+                              <button
+                                type="button"
+                                disabled={!apt.notes && !apt.report}
+                                aria-disabled={!apt.notes && !apt.report}
+                                className={`text-xs px-2 py-1 rounded border ${(!apt.notes && !apt.report) ? 'opacity-50 cursor-not-allowed text-gray-400 border-gray-200' : 'hover:bg-gray-50'}`}
+                                onClick={() => setExpanded((prev) => ({ ...prev, [apt.id]: !prev[apt.id] }))}
+                              >
+                                {expanded[apt.id] ? 'Masquer' : 'Détails'}
+                              </button>
+                            </div>
+                          </div>
+                          {expanded[apt.id] ? (
+                            <div className="mt-2 grid grid-cols-1 md:grid-cols-2 gap-2">
+                              {apt.notes ? (
+                                <div className="bg-yellow-50 border border-yellow-200 rounded p-2">
+                                  <div className="text-xs font-medium text-yellow-800">Notes internes</div>
+                                  <p className="text-sm text-yellow-900 whitespace-pre-wrap">{apt.notes}</p>
+                                </div>
+                              ) : null}
+                              {apt.report ? (
+                                <div className="bg-green-50 border border-green-200 rounded p-2">
+                                  <div className="text-xs font-medium text-green-800">Compte-rendu</div>
+                                  <p className="text-sm text-green-900 whitespace-pre-wrap">{apt.report}</p>
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : null}
                         </li>
                       ))}
                       {history.appointments.length === 0 ? <li className="text-gray-600">Aucun historique</li> : null}

--- a/apps/web/src/pages/__tests__/VetAgenda.test.tsx
+++ b/apps/web/src/pages/__tests__/VetAgenda.test.tsx
@@ -26,6 +26,7 @@ vi.mock('../../services/clinics.service', () => ({
 vi.mock('../../services/appointments.service', () => ({
   appointmentsService: {
     completeAppointment: vi.fn(),
+    confirmAppointment: vi.fn(),
   }
 }));
 
@@ -142,6 +143,33 @@ describe('VetAgenda', () => {
         notes: 'Test notes',
         report: 'Test report',
       });
+    });
+  });
+
+  it('allows confirming a pending appointment from the modal', async () => {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 11, 0).toISOString();
+    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 11, 30).toISOString();
+    (agendaService.getMyDay as any).mockResolvedValue([
+      { id: 'apt-pending', startsAt: start, endsAt: end, status: 'PENDING', animal: { name: 'Lucky' }, owner: { firstName: 'O', lastName: 'N', email: 'o@n' } },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Lucky/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Détails'));
+    await waitFor(() => {
+      expect(screen.getByText(/Détails du rendez-vous/)).toBeInTheDocument();
+    });
+
+    // Click "Valider" button
+    fireEvent.click(screen.getByRole('button', { name: 'Valider' }));
+
+    await waitFor(() => {
+      expect(appointmentsService.confirmAppointment).toHaveBeenCalledWith('apt-pending');
     });
   });
 

--- a/apps/web/src/pages/owner/OwnerAppointments.tsx
+++ b/apps/web/src/pages/owner/OwnerAppointments.tsx
@@ -1,4 +1,14 @@
 import { useEffect, useState } from 'react';
+const STATUS_LABELS: Record<string, string> = {
+  PENDING: 'En attente',
+  CONFIRMED: 'Confirmé',
+  REJECTED: 'Refusé',
+  CANCELLED: 'Annulé',
+  COMPLETED: 'Terminé',
+};
+function statusLabel(status: string): string {
+  return STATUS_LABELS[status] ?? status;
+}
 import { appointmentsService, type AppointmentResponse } from '../../services/appointments.service';
 
 export function OwnerAppointments() {
@@ -34,11 +44,11 @@ export function OwnerAppointments() {
             <label className="block text-sm text-gray-700">Filtrer par statut</label>
             <select value={status} onChange={(e) => setStatus(e.target.value as AppointmentResponse['status'])} className="mt-1 border rounded p-2">
               <option value="">Tous</option>
-              <option value="PENDING">PENDING</option>
-              <option value="CONFIRMED">CONFIRMED</option>
-              <option value="REJECTED">REJECTED</option>
-              <option value="CANCELLED">CANCELLED</option>
-              <option value="COMPLETED">COMPLETED</option>
+              <option value="PENDING">{statusLabel('PENDING')}</option>
+              <option value="CONFIRMED">{statusLabel('CONFIRMED')}</option>
+              <option value="REJECTED">{statusLabel('REJECTED')}</option>
+              <option value="CANCELLED">{statusLabel('CANCELLED')}</option>
+              <option value="COMPLETED">{statusLabel('COMPLETED')}</option>
             </select>
           </div>
           <button type="button" className="px-3 py-2 border rounded" onClick={load} disabled={loading}>Rafraîchir</button>
@@ -57,7 +67,7 @@ export function OwnerAppointments() {
                     <div className="font-medium">{s.toLocaleDateString()} {s.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })} → {e.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</div>
                     <div className="text-sm text-gray-600">Vétérinaire: {a.vet ? `${a.vet.firstName} ${a.vet.lastName}` : '—'}</div>
                   </div>
-                  <span className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700">{a.status}</span>
+                  <span className="text-xs px-2 py-1 rounded bg-blue-50 text-blue-700">{statusLabel(a.status)}</span>
                 </div>
               </div>
             );

--- a/apps/web/src/pages/vet/VetAnimals.tsx
+++ b/apps/web/src/pages/vet/VetAnimals.tsx
@@ -1,0 +1,122 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { agendaService, type AgendaItem } from '../../services/agenda.service';
+import type { AnimalDto } from '../../services/animals.service';
+import { AnimalDetailsModal } from '../../components/AnimalDetailsModal';
+
+function toYmd(d: Date) {
+  return d.toISOString().split('T')[0];
+}
+
+export function VetAnimals() {
+  const [date, setDate] = useState<string>(toYmd(new Date()));
+  const [items, setItems] = useState<AgendaItem[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [selectedAnimal, setSelectedAnimal] = useState<AnimalDto | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const month = await agendaService.getMyMonth(date);
+      setItems(month);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Erreur');
+    } finally {
+      setLoading(false);
+    }
+  }, [date]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const animals = useMemo(() => {
+    const map = new Map<string, AnimalDto>();
+    for (const it of items) {
+      if (it.animal?.id) {
+        map.set(it.animal.id, {
+          id: it.animal.id,
+          clinicId: '',
+          ownerId: '',
+          name: it.animal.name,
+          birthdate: it.animal.birthdate ?? undefined,
+          species: it.animal.species ?? undefined,
+          breed: it.animal.breed ?? undefined,
+          weightKg: it.animal.weightKg ?? undefined,
+        } as AnimalDto);
+      }
+    }
+    return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+  }, [items]);
+
+  const emojiForSpecies = useMemo(() => {
+    return (species?: string | null): string => {
+      if (!species) return '🐾';
+      const s = species.toLowerCase();
+      if (s.includes('chien') || s.includes('dog')) return '🐶';
+      if (s.includes('chat') || s.includes('cat')) return '🐱';
+      if (s.includes('lapin') || s.includes('rabbit')) return '🐰';
+      if (s.includes('hamster')) return '🐹';
+      if (s.includes('oiseau') || s.includes('bird') || s.includes('perruche')) return '🐦';
+      if (s.includes('poisson') || s.includes('fish')) return '🐟';
+      if (s.includes('cheval') || s.includes('horse')) return '🐴';
+      if (s.includes('tortue') || s.includes('turtle')) return '🐢';
+      if (s.includes('serpent') || s.includes('snake')) return '🐍';
+      if (s.includes('furet')) return '🦦';
+      if (s.includes('cochon d') || s.includes('guinea')) return '🐹';
+      return '🐾';
+    };
+  }, []);
+
+  return (
+    <div className="min-h-screen bg-gray-50 py-8">
+      <div className="mx-auto max-w-5xl px-4">
+        <div className="flex items-end gap-3 mb-4">
+          <div>
+            <label className="block text-sm text-gray-700">Mois</label>
+            <input type="month" value={date.slice(0,7)} onChange={(e) => {
+              const v = e.target.value; // yyyy-mm
+              const d = new Date(v + '-01');
+              setDate(toYmd(d));
+            }} className="mt-1 border rounded p-2" />
+          </div>
+          <button type="button" className="ml-auto px-3 py-2 border rounded" onClick={load} disabled={loading}>Rafraîchir</button>
+        </div>
+        {loading ? <div>Chargement…</div> : null}
+        {error ? <div className="text-red-700 bg-red-50 border border-red-200 rounded p-2">{error}</div> : null}
+
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {animals.map((an) => (
+            <button
+              key={an.id}
+              className="border rounded-lg p-4 bg-white hover:bg-gray-50 text-left flex items-center gap-4"
+              onClick={() => setSelectedAnimal(an)}
+            >
+              <div className="text-3xl" aria-hidden>{emojiForSpecies(an.species)}</div>
+              <div>
+                <div className="font-medium text-lg">{an.name}</div>
+                <div className="text-sm text-gray-600">
+                  {an.species && an.breed ? `${an.species} • ${an.breed}` : an.species || an.breed || '—'}
+                </div>
+              </div>
+            </button>
+          ))}
+        </div>
+        {!loading && !error && animals.length === 0 ? (
+          <div className="text-gray-600 mt-3">Aucun animal suivi ce mois-ci.</div>
+        ) : null}
+
+        <AnimalDetailsModal
+          isOpen={selectedAnimal != null}
+          onClose={() => setSelectedAnimal(null)}
+          animal={selectedAnimal}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default VetAnimals;
+
+

--- a/apps/web/src/pages/vet/__tests__/VetAnimals.test.tsx
+++ b/apps/web/src/pages/vet/__tests__/VetAnimals.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { VetAnimals } from '../../vet/VetAnimals';
+import { agendaService } from '../../../services/agenda.service';
+
+vi.mock('../../../services/agenda.service', () => ({
+  agendaService: {
+    getMyMonth: vi.fn(),
+  },
+}));
+
+vi.mock('../../../services/animals.service', () => ({
+  animalsService: {
+    getHistory: vi.fn().mockResolvedValue({ animal: { id: 'an1', name: 'Rex' }, appointments: [] }),
+  },
+}));
+
+vi.mock('../../../services/documents.service', () => ({
+  documentsService: {
+    getDocumentsForAppointment: vi.fn().mockResolvedValue([]),
+  },
+}));
+
+describe('VetAnimals page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function renderPage() {
+    return render(
+      <MemoryRouter initialEntries={["/vet/animals"]}>
+        <Routes>
+          <Route path="/vet/animals" element={<VetAnimals />} />
+        </Routes>
+      </MemoryRouter>
+    );
+  }
+
+  it('lists animals deduplicated from monthly agenda and opens details modal', async () => {
+    (agendaService.getMyMonth as any).mockResolvedValue([
+      { id: 'a1', startsAt: new Date().toISOString(), endsAt: new Date().toISOString(), status: 'CONFIRMED', animal: { id: 'an1', name: 'Rex', species: 'Chien', breed: 'Berger' } },
+      { id: 'a2', startsAt: new Date().toISOString(), endsAt: new Date().toISOString(), status: 'CONFIRMED', animal: { id: 'an1', name: 'Rex', species: 'Chien', breed: 'Berger' } },
+      { id: 'a3', startsAt: new Date().toISOString(), endsAt: new Date().toISOString(), status: 'PENDING', animal: { id: 'an2', name: 'Misty', species: 'Chat', breed: 'Européen' } },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('Rex')).toBeInTheDocument();
+      expect(screen.getByText('Misty')).toBeInTheDocument();
+    });
+
+    // Open details modal on click
+    fireEvent.click(screen.getByText('Rex'));
+    await waitFor(() => {
+      // Modal title shows animal name (heading inside modal)
+      expect(screen.getByRole('heading', { name: 'Rex' })).toBeInTheDocument();
+    });
+  });
+});
+
+


### PR DESCRIPTION
This pull request introduces a new "Mes patients" (My Patients) page for veterinarians and enhances the usability and clarity of appointment and animal history displays across the app. The main improvements include more informative status labels, expandable details for appointments and reports, and new actions for pending appointments. The changes also include updated tests to cover these new features.

**New Vet Animals Page and Navigation**

* Added `VetAnimals` page and route (`/vet/animals`) for veterinarians, along with a dashboard card for easy access. [[1]](diffhunk://#diff-25cc6f821b468a3795b6b1858368fd559c50e2aa21ef8bf1a5def5c771cac042R18) [[2]](diffhunk://#diff-25cc6f821b468a3795b6b1858368fd559c50e2aa21ef8bf1a5def5c771cac042R162-R166) [[3]](diffhunk://#diff-c8d52f4b7c33310f59b19d0d7686a96d58684e5e69e6e14e35d87250ea527079R25-R34)

**Appointment and Animal History UI Improvements**

* Appointment and animal history lists now use readable French status labels via the new `statusLabel` helper in several files (`AnimalDetailsModal.tsx`, `VetAgenda.tsx`, `OwnerAppointments.tsx`). [[1]](diffhunk://#diff-62a3f8040f589a07a0641bec63039b9910720becba0f04a8b49ac56e3c9fbecbR7-R17) [[2]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaR2-R14) [[3]](diffhunk://#diff-f4d4bd3f41302c2e462a6a09a1888fb28885e97fedf2c8988200a2fa0a7ada18R2-R11)
* Appointment and report details are now shown in expandable sections ("Détails"/"Masquer" buttons) for better readability and to reduce clutter, including animal history and recent reports. [[1]](diffhunk://#diff-62a3f8040f589a07a0641bec63039b9910720becba0f04a8b49ac56e3c9fbecbR52) [[2]](diffhunk://#diff-62a3f8040f589a07a0641bec63039b9910720becba0f04a8b49ac56e3c9fbecbL152-R203) [[3]](diffhunk://#diff-62a3f8040f589a07a0641bec63039b9910720becba0f04a8b49ac56e3c9fbecbL169-R256) [[4]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaL593-R700)

**Actions for Pending Appointments**

* Veterinarians can now confirm pending appointments directly from the modal with a "Valider" button; the action is tested and integrated with the backend. [[1]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaR529-R541) [[2]](diffhunk://#diff-187c9d1efe9506ba2fd78fe5a8f333c38330555aecd43dc8d8e95be3e648fd53R29) [[3]](diffhunk://#diff-187c9d1efe9506ba2fd78fe5a8f333c38330555aecd43dc8d8e95be3e648fd53R149-R175) [[4]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaL593-R700)

**Consistent Status Display**

* All appointment status displays in agenda views, modals, and history lists now use the new status labels for consistency and clarity. [[1]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaL346-R359) [[2]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaL701-R798)

**Test Updates**

* Tests for `AnimalDetailsModal` and `VetAgenda` updated to cover expandable report details and appointment confirmation actions. [[1]](diffhunk://#diff-8499750f3d6ca696b4c55348f92771f48b0bb9b7d9dd46add5886d000dcceb22L1-R1) [[2]](diffhunk://#diff-8499750f3d6ca696b4c55348f92771f48b0bb9b7d9dd46add5886d000dcceb22L113-R126) [[3]](diffhunk://#diff-187c9d1efe9506ba2fd78fe5a8f333c38330555aecd43dc8d8e95be3e648fd53R29) [[4]](diffhunk://#diff-187c9d1efe9506ba2fd78fe5a8f333c38330555aecd43dc8d8e95be3e648fd53R149-R175)