### PR TITLE
Feat/reject appointment

### DIFF
--- a/apps/api/src/appointments/appointments.controller.spec.ts
+++ b/apps/api/src/appointments/appointments.controller.spec.ts
@@ -14,6 +14,7 @@ describe('AppointmentsController', () => {
     createAppointment: jest.fn(),
     getPendingAppointments: jest.fn(),
     confirmAppointment: jest.fn(),
+    rejectAppointment: jest.fn(),
   } as unknown as AppointmentsService;
 
   beforeEach(async () => {
@@ -85,6 +86,18 @@ describe('AppointmentsController', () => {
     expect(res).toMatchObject({
       id: 'apt',
       message: 'Appointment confirmed successfully.',
+    });
+  });
+
+  it('should reject appointment and return message', async () => {
+    (service.rejectAppointment as any) = jest
+      .fn()
+      .mockResolvedValue({ id: 'apt', status: 'REJECTED' });
+    const res = await controller.rejectAppointment('apt');
+    expect(service.rejectAppointment).toHaveBeenCalledWith('apt');
+    expect(res).toMatchObject({
+      id: 'apt',
+      message: 'Appointment rejected successfully.',
     });
   });
 });

--- a/apps/api/src/appointments/appointments.controller.ts
+++ b/apps/api/src/appointments/appointments.controller.ts
@@ -257,6 +257,42 @@ export class AppointmentsController {
     };
   }
 
+  @Patch(':id/reject')
+  @Roles('ASV', 'VET', 'ADMIN_CLINIC')
+  @ApiOperation({
+    summary: 'Refuser un rendez-vous',
+    description: 'Refuse un rendez-vous en attente (ASV, VET, ADMIN_CLINIC)',
+  })
+  @ApiParam({
+    name: 'id',
+    description: 'ID du rendez-vous à refuser',
+    type: 'string',
+  })
+  @ApiOkResponse({
+    description: 'Rendez-vous refusé avec succès',
+    schema: {
+      type: 'object',
+      properties: {
+        id: { type: 'string' },
+        status: { type: 'string', example: 'REJECTED' },
+        message: {
+          type: 'string',
+          example: 'Appointment rejected successfully.',
+        },
+      },
+    },
+  })
+  @ApiUnauthorizedResponse({ description: 'Token JWT invalide ou manquant' })
+  @ApiForbiddenResponse({ description: 'Permissions insuffisantes' })
+  @ApiNotFoundResponse({ description: 'Rendez-vous non trouvé' })
+  async rejectAppointment(@Param('id') id: string) {
+    const appointment = await this.appointmentsService.rejectAppointment(id);
+    return {
+      ...appointment,
+      message: 'Appointment rejected successfully.',
+    };
+  }
+
   @Patch(':id/complete')
   @Roles('VET')
   @ApiOperation({

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -539,5 +539,19 @@ describe('AppointmentsService', () => {
         service.completeAppointment('apt-1', 'vet-1', {}),
       ).rejects.toThrow(ConflictException);
     });
+
+    it('should throw ConflictException if appointment is not confirmed', async () => {
+      const appointment = {
+        id: 'apt-2',
+        vetUserId: 'vet-1',
+        status: 'PENDING',
+      };
+      jest
+        .spyOn(appointmentRepo, 'findOne')
+        .mockResolvedValue(appointment as any);
+      await expect(
+        service.completeAppointment('apt-2', 'vet-1', {}),
+      ).rejects.toThrow(ConflictException);
+    });
   });
 });

--- a/apps/api/src/appointments/appointments.service.spec.ts
+++ b/apps/api/src/appointments/appointments.service.spec.ts
@@ -424,6 +424,49 @@ describe('AppointmentsService', () => {
     });
   });
 
+  describe('rejectAppointment', () => {
+    it('rejects a pending appointment', async () => {
+      const pending: Appointment = {
+        id: 'x',
+        clinicId: 'c',
+        animalId: 'an',
+        vetUserId: 'v',
+        status: 'PENDING',
+        startsAt: new Date('2024-01-10T10:00:00.000Z'),
+        endsAt: new Date('2024-01-10T10:30:00.000Z'),
+        createdByUserId: 'creator',
+        createdAt: new Date('2024-01-09T12:00:00.000Z'),
+        updatedAt: new Date('2024-01-09T12:00:00.000Z'),
+        typeId: null,
+      } as any;
+
+      (appointmentRepo.findOne as any) = jest.fn().mockResolvedValue(pending);
+      (appointmentRepo.save as any) = jest
+        .fn()
+        .mockImplementation((a: Appointment) => ({ ...a }));
+
+      const res = await service.rejectAppointment('x');
+      expect(res.status).toBe('REJECTED');
+      expect(appointmentRepo.save).toHaveBeenCalled();
+    });
+
+    it('throws NotFoundException when appointment missing', async () => {
+      (appointmentRepo.findOne as any) = jest.fn().mockResolvedValue(null);
+      await expect(service.rejectAppointment('missing')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('throws ConflictException when status not PENDING', async () => {
+      (appointmentRepo.findOne as any) = jest
+        .fn()
+        .mockResolvedValue({ id: 'z', status: 'CONFIRMED' });
+      await expect(service.rejectAppointment('z')).rejects.toThrow(
+        ConflictException,
+      );
+    });
+  });
+
   describe('completeAppointment', () => {
     it('should complete an appointment with notes and report', async () => {
       const appointmentId = 'apt-1';

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -302,6 +302,10 @@ export class AppointmentsService {
       throw new ConflictException('Appointment is already completed');
     }
 
+    if (appointment.status !== 'CONFIRMED') {
+      throw new ConflictException('Appointment is not confirmed');
+    }
+
     appointment.notes = completeDto.notes ?? appointment.notes;
     appointment.report = completeDto.report ?? appointment.report;
     appointment.status = 'COMPLETED';

--- a/apps/api/src/appointments/appointments.service.ts
+++ b/apps/api/src/appointments/appointments.service.ts
@@ -250,6 +250,35 @@ export class AppointmentsService {
     };
   }
 
+  async rejectAppointment(id: string): Promise<AppointmentResponse> {
+    const appointment = await this.appointmentRepository.findOne({
+      where: { id },
+    });
+
+    if (!appointment) {
+      throw new NotFoundException('Appointment not found');
+    }
+
+    if (appointment.status !== 'PENDING') {
+      throw new ConflictException('Appointment is not pending');
+    }
+
+    appointment.status = 'REJECTED';
+    const saved = await this.appointmentRepository.save(appointment);
+
+    return {
+      id: saved.id,
+      clinicId: saved.clinicId,
+      animalId: saved.animalId ?? undefined,
+      vetUserId: saved.vetUserId ?? undefined,
+      typeId: saved.typeId ?? undefined,
+      status: saved.status,
+      startsAt: saved.startsAt.toISOString(),
+      endsAt: saved.endsAt.toISOString(),
+      createdAt: saved.createdAt.toISOString(),
+    };
+  }
+
   async completeAppointment(
     id: string,
     vetUserId: string,

--- a/apps/web/src/components/HealthCheck.tsx
+++ b/apps/web/src/components/HealthCheck.tsx
@@ -13,11 +13,11 @@ export function HealthCheck() {
     const checkHealth = async () => {
       try {
         const data = await httpService.get<HealthStatus>('/health');
-        // eslint-disable-next-line no-console
+         
         console.info('[VitaVet] API health', data);
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Unknown error';
-        // eslint-disable-next-line no-console
+         
         console.warn('[VitaVet] API health error', message);
       }
     };

--- a/apps/web/src/pages/VetAgenda.tsx
+++ b/apps/web/src/pages/VetAgenda.tsx
@@ -780,7 +780,7 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
 
             <div className="mt-4 flex justify-end gap-2">
               <button className="px-4 py-2 border rounded" onClick={onClose}>Fermer</button>
-              {item.status !== 'COMPLETED' && (
+              {item.status === 'CONFIRMED' && (
                 <button className="px-4 py-2 bg-green-600 text-white rounded" onClick={() => setIsCompleting(true)}>
                   Compléter le RDV
                 </button>

--- a/apps/web/src/pages/VetAgenda.tsx
+++ b/apps/web/src/pages/VetAgenda.tsx
@@ -539,6 +539,20 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
     }
   };
 
+  const handleRejectPending = async () => {
+    if (!window.confirm('Confirmer le refus de ce rendez-vous ?')) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await appointmentsService.rejectAppointment(item.id);
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to reject appointment');
+    } finally {
+      setLoading(false);
+    }
+  };
+
   const handleFileUpload = async () => {
     if (!file) return;
     setUploading(true);
@@ -629,9 +643,9 @@ function AgendaItemModal({ item, onClose }: { item: AgendaItem; onClose: () => v
                     </button>
                     <button
                       type="button"
-                      className="text-xs px-2 py-1 rounded bg-gray-200 text-gray-600 cursor-not-allowed"
-                      title="Refus non disponible pour le moment"
-                      disabled
+                      className="text-xs px-2 py-1 rounded bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+                      onClick={handleRejectPending}
+                      disabled={loading}
                     >
                       Refuser
                     </button>

--- a/apps/web/src/pages/__tests__/VetAgenda.test.tsx
+++ b/apps/web/src/pages/__tests__/VetAgenda.test.tsx
@@ -176,6 +176,28 @@ describe('VetAgenda', () => {
     });
   });
 
+  it('hides complete button when status is not CONFIRMED', async () => {
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 13, 0).toISOString();
+    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 13, 30).toISOString();
+    (agendaService.getMyDay as any).mockResolvedValue([
+      { id: 'apt-rejected', startsAt: start, endsAt: end, status: 'REJECTED', animal: { name: 'Kitty' } },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Kitty/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Détails'));
+    await waitFor(() => {
+      expect(screen.getByText(/Détails du rendez-vous/)).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: 'Compléter le RDV' })).not.toBeInTheDocument();
+  });
+
   it('allows rejecting a pending appointment from the modal', async () => {
     // Mock confirm dialog
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);

--- a/apps/web/src/pages/__tests__/VetAgenda.test.tsx
+++ b/apps/web/src/pages/__tests__/VetAgenda.test.tsx
@@ -1,5 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import React from 'react';
+import '@testing-library/jest-dom';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { VetAgenda } from '../VetAgenda';
 import { agendaService } from '../../services/agenda.service';
@@ -27,6 +29,7 @@ vi.mock('../../services/appointments.service', () => ({
   appointmentsService: {
     completeAppointment: vi.fn(),
     confirmAppointment: vi.fn(),
+    rejectAppointment: vi.fn(),
   }
 }));
 
@@ -171,6 +174,38 @@ describe('VetAgenda', () => {
     await waitFor(() => {
       expect(appointmentsService.confirmAppointment).toHaveBeenCalledWith('apt-pending');
     });
+  });
+
+  it('allows rejecting a pending appointment from the modal', async () => {
+    // Mock confirm dialog
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    const now = new Date();
+    const start = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12, 0).toISOString();
+    const end = new Date(now.getFullYear(), now.getMonth(), now.getDate(), 12, 30).toISOString();
+    (agendaService.getMyDay as any).mockResolvedValue([
+      { id: 'apt-pending-2', startsAt: start, endsAt: end, status: 'PENDING', animal: { name: 'Moka' }, owner: { firstName: 'O', lastName: 'N', email: 'o@n' } },
+    ]);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Moka/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Détails'));
+    await waitFor(() => {
+      expect(screen.getByText(/Détails du rendez-vous/)).toBeInTheDocument();
+    });
+
+    // Click "Refuser" button
+    fireEvent.click(screen.getByRole('button', { name: 'Refuser' }));
+
+    await waitFor(() => {
+      expect(appointmentsService.rejectAppointment).toHaveBeenCalledWith('apt-pending-2');
+    });
+
+    confirmSpy.mockRestore();
   });
 
   it('shows legend and allows hiding blocks (filters)', async () => {

--- a/apps/web/src/services/__tests__/appointments.service.test.ts
+++ b/apps/web/src/services/__tests__/appointments.service.test.ts
@@ -39,6 +39,13 @@ describe('appointments.service', () => {
     expect(httpService.get).toHaveBeenCalledWith('/appointments/me?status=PENDING');
   });
 
+  it('rejectAppointment calls backend endpoint', async () => {
+    (httpService.patch as any).mockResolvedValue({ id: 'a1', status: 'REJECTED' });
+    const res = await appointmentsService.rejectAppointment('a1');
+    expect(httpService.patch).toHaveBeenCalledWith('/appointments/a1/reject');
+    expect(res.status).toBe('REJECTED');
+  });
+
   it('getPendingAppointments constructs params', async () => {
     (httpService.get as any).mockResolvedValue({ appointments: [], total: 0 });
     await appointmentsService.getPendingAppointments('c1', 10, 5);

--- a/apps/web/src/services/appointments.service.ts
+++ b/apps/web/src/services/appointments.service.ts
@@ -83,6 +83,10 @@ class AppointmentsService {
   async completeAppointment(id: string, data: CompleteAppointmentData): Promise<AppointmentResponse> {
     return httpService.patch<AppointmentResponse>(`/appointments/${id}/complete`, data);
   }
+
+  async rejectAppointment(id: string): Promise<AppointmentResponse> {
+    return httpService.patch<AppointmentResponse>(`/appointments/${id}/reject`);
+  }
 }
 
 export const appointmentsService = new AppointmentsService();


### PR DESCRIPTION
This pull request adds support for rejecting pending appointments across both backend and frontend, including API endpoints, service logic, UI updates, and test coverage. The main changes introduce a new `rejectAppointment` feature, allowing authorized users to refuse appointments that are in a pending state, and ensure that the UI and tests reflect this new capability.

### Backend changes

**Appointments API and service logic:**

* Added a new `PATCH /appointments/:id/reject` endpoint in `AppointmentsController` that allows users with appropriate roles to reject a pending appointment, returning a success message and updated status.
* Implemented the `rejectAppointment` method in `AppointmentsService` to update the appointment status to `REJECTED`, with error handling for not found or invalid status cases.
* Updated `completeAppointment` logic to throw a `ConflictException` if the appointment is not confirmed, enforcing correct status transitions.

**Backend tests:**

* Added tests for the new `rejectAppointment` controller and service logic, including success, not found, and conflict scenarios. [[1]](diffhunk://#diff-523f9b166eb8aad53409c14655d2167df72166289e8702d8737f093d582e62b3R91-R102) [[2]](diffhunk://#diff-cef8c257b769bf6b791c527d4190228f79d94a90afefe81170ae5f6cae94cb3bR427-R469)

### Frontend changes

**UI and modal behavior:**

* Enabled the "Refuser" button for pending appointments in the `VetAgenda` modal, with a confirmation dialog and error handling. The button is now active for pending appointments and triggers the new backend logic. [[1]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaR542-R555) [[2]](diffhunk://#diff-6fcab8d6d75bd35c211fc3eba438aca85921f901a787a6115cc8ada47d5332eaL632-R648)
* Updated modal logic so that the "Compléter le RDV" button is only shown for confirmed appointments, reflecting the new backend restrictions.

**Frontend tests and services:**

* Added `rejectAppointment` to the frontend service and tested that it calls the backend endpoint correctly. [[1]](diffhunk://#diff-d29a85c0247ec93f4f8ce2384de3a28d9cc1aa946e2f04fa0394553c66533647R86-R89) [[2]](diffhunk://#diff-434fd57b3bbfd1972dbc352b9e6b7fb115125a51afb5686f9b35530f7395acfbR42-R48)
* Updated `VetAgenda` tests to verify that the complete button is hidden for non-confirmed appointments and that rejecting pending appointments works as expected.

---

These changes ensure that rejecting appointments is now a supported, tested, and user-accessible feature in both the backend and frontend.