### PR TITLE
Feat/owner delete animal

### DIFF
--- a/apps/api/src/animals/animals.controller.spec.ts
+++ b/apps/api/src/animals/animals.controller.spec.ts
@@ -15,6 +15,7 @@ describe('AnimalsController', () => {
     getAnimalHistory: jest.fn(),
     createAnimal: jest.fn(),
     updateAnimal: jest.fn(),
+    deleteAnimal: jest.fn(),
   };
 
   beforeEach(async () => {
@@ -119,6 +120,19 @@ describe('AnimalsController', () => {
         dto,
       );
       expect(result).toEqual(updated);
+    });
+  });
+
+  describe('deleteAnimal', () => {
+    it('should delete animal and return 204', async () => {
+      const mockUser = { id: 'user-123' } as User;
+      mockAnimalsService.deleteAnimal.mockResolvedValue(undefined);
+      const res = await controller.deleteAnimal(mockUser, 'animal-123');
+      expect(mockAnimalsService.deleteAnimal).toHaveBeenCalledWith(
+        'user-123',
+        'animal-123',
+      );
+      expect(res).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/animals/animals.controller.ts
+++ b/apps/api/src/animals/animals.controller.ts
@@ -3,10 +3,12 @@ import {
   Get,
   Post,
   Patch,
+  Delete,
   Param,
   Query,
   UseGuards,
   Body,
+  HttpCode,
 } from '@nestjs/common';
 import { AnimalsService } from './animals.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
@@ -126,8 +128,6 @@ export class AnimalsController {
     return this.animalsService.findByOwnerAndClinic(user.id, clinicId);
   }
 
-  // US-05a: View animal history
-  // Access: OWNER of the animal, or VET/ASV/ADMIN_CLINIC of the same clinic
   @Get(':animalId/history')
   @ApiOperation({
     summary: "Obtenir l'historique d'un animal",
@@ -219,5 +219,22 @@ export class AnimalsController {
     @Body() dto: UpdateAnimalDto,
   ) {
     return this.animalsService.updateAnimal(user.id, animalId, dto);
+  }
+
+  @ApiOperation({ summary: 'Supprimer un animal' })
+  @ApiParam({ name: 'animalId', description: "ID de l'animal", type: 'string' })
+  @ApiUnauthorizedResponse({ description: 'Token JWT invalide ou manquant' })
+  @ApiForbiddenResponse({
+    description: 'Permissions insuffisantes (OWNER requis)',
+  })
+  @ApiNotFoundResponse({ description: 'Animal non trouvé' })
+  @Roles('OWNER')
+  @Delete(':animalId')
+  @HttpCode(204)
+  async deleteAnimal(
+    @CurrentUser() user: User,
+    @Param('animalId') animalId: string,
+  ) {
+    await this.animalsService.deleteAnimal(user.id, animalId);
   }
 }

--- a/apps/api/src/animals/animals.service.spec.ts
+++ b/apps/api/src/animals/animals.service.spec.ts
@@ -6,6 +6,7 @@ import { Animal } from './entities/animal.entity';
 import { Appointment } from '../appointments/entities/appointment.entity';
 import { UserClinicRole } from '../users/entities/user-clinic-role.entity';
 import { Clinic } from '../clinics/entities/clinic.entity';
+import { DataSource } from 'typeorm';
 import { NotFoundException, ForbiddenException } from '@nestjs/common';
 import { UpdateAnimalDto } from './dto/update-animal.dto';
 
@@ -46,6 +47,18 @@ describe('AnimalsService', () => {
           useValue: userClinicRoleRepoMock,
         },
         { provide: getRepositoryToken(Clinic), useValue: clinicRepoMock },
+        {
+          provide: DataSource,
+          useValue: {
+            transaction: jest
+              .fn()
+              .mockImplementation(
+                (cb: (tx: { remove: jest.Mock }) => Promise<void> | void) => {
+                  return cb({ remove: jest.fn() } as any);
+                },
+              ),
+          },
+        },
       ],
     }).compile();
 
@@ -190,6 +203,42 @@ describe('AnimalsService', () => {
       expect(repo.save).toHaveBeenCalled();
       expect(res.name).toBe('New');
       expect(res.weightKg).toBe(12.3);
+    });
+  });
+
+  describe('deleteAnimal', () => {
+    it('throws NotFoundException if animal not found', async () => {
+      (repo.findOne as any) = jest.fn().mockResolvedValue(null);
+      await expect(service.deleteAnimal('owner1', 'missing')).rejects.toThrow(
+        'Animal not found',
+      );
+    });
+
+    it('throws ForbiddenException if requester not owner', async () => {
+      (repo.findOne as any) = jest
+        .fn()
+        .mockResolvedValue({ id: 'a1', ownerId: 'other' });
+      await expect(service.deleteAnimal('owner1', 'a1')).rejects.toThrow(
+        'Only owner can delete animal',
+      );
+    });
+
+    it('deletes animal in transaction', async () => {
+      const toDelete = { id: 'a1', ownerId: 'owner1' } as any;
+      (repo.findOne as any) = jest.fn().mockResolvedValue(toDelete);
+      const tx = { remove: jest.fn().mockResolvedValue(undefined) };
+      const ds = (service as any).dataSource as DataSource;
+      (ds.transaction as any) = jest
+        .fn()
+        .mockImplementation(
+          async (cb: (t: typeof tx) => Promise<void> | void) => {
+            await cb(tx);
+          },
+        );
+
+      await service.deleteAnimal('owner1', 'a1');
+      expect(ds.transaction).toHaveBeenCalled();
+      expect(tx.remove).toHaveBeenCalledWith(toDelete);
     });
   });
 });

--- a/apps/api/src/animals/animals.service.ts
+++ b/apps/api/src/animals/animals.service.ts
@@ -11,6 +11,7 @@ import { UserClinicRole } from '../users/entities/user-clinic-role.entity';
 import { CreateAnimalDto } from './dto/create-animal.dto';
 import { UpdateAnimalDto } from './dto/update-animal.dto';
 import { Clinic } from '../clinics/entities/clinic.entity';
+import { DataSource } from 'typeorm';
 
 @Injectable()
 export class AnimalsService {
@@ -23,6 +24,7 @@ export class AnimalsService {
     private readonly userClinicRoleRepository: Repository<UserClinicRole>,
     @InjectRepository(Clinic)
     private readonly clinicRepository: Repository<Clinic>,
+    private readonly dataSource: DataSource,
   ) {}
 
   async createAnimal(
@@ -134,5 +136,21 @@ export class AnimalsService {
       }
     }
     return this.animalRepository.save(animal);
+  }
+
+  async deleteAnimal(requesterId: string, animalId: string): Promise<void> {
+    const animal = await this.animalRepository.findOne({
+      where: { id: animalId },
+    });
+    if (!animal) throw new NotFoundException('Animal not found');
+    if (animal.ownerId !== requesterId) {
+      throw new ForbiddenException('Only owner can delete animal');
+    }
+
+    // Use a transaction to ensure consistency if cascade is incomplete
+    await this.dataSource.transaction(async (manager) => {
+      // With onDelete: 'CASCADE' on relations, removing the animal will cascade
+      await manager.remove(animal);
+    });
   }
 }

--- a/apps/api/src/reminders/entities/reminder-instance.entity.ts
+++ b/apps/api/src/reminders/entities/reminder-instance.entity.ts
@@ -26,7 +26,7 @@ export class ReminderInstance {
   @Column('uuid', { name: 'appointment_id', nullable: true })
   appointmentId?: string | null;
 
-  @ManyToOne(() => Appointment, { nullable: true })
+  @ManyToOne(() => Appointment, { nullable: true, onDelete: 'CASCADE' })
   @JoinColumn({ name: 'appointment_id' })
   appointment?: Appointment;
 

--- a/apps/web/src/components/AnimalDetailsModal.tsx
+++ b/apps/web/src/components/AnimalDetailsModal.tsx
@@ -52,6 +52,7 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 	const [isEditing, setIsEditing] = useState(false);
 	const [editError, setEditError] = useState<string | null>(null);
 	const [saving, setSaving] = useState(false);
+	const [deleting, setDeleting] = useState(false);
 	interface EditForm {
 		name: string;
 		birthdate: string | '';
@@ -190,6 +191,26 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 							aria-controls="animal-edit-form"
 						>
 							{isEditing ? 'Annuler' : 'Modifier'}
+						</button>
+						<button
+							type="button"
+							className="text-sm px-3 py-1 border rounded text-red-700 border-red-300 hover:bg-red-50 disabled:opacity-50"
+							disabled={deleting}
+							onClick={async () => {
+								if (!window.confirm('Supprimer définitivement cet animal ? Cette action est irréversible.')) return;
+								try {
+									setDeleting(true);
+									await animalsService.deleteAnimal(animal.id);
+									onClose();
+								} catch (e) {
+									setError(e instanceof Error ? e.message : 'Erreur lors de la suppression');
+								} finally {
+									setDeleting(false);
+								}
+							}}
+							aria-label="Supprimer l'animal"
+						>
+							{deleting ? 'Suppression…' : 'Supprimer'}
 						</button>
 						<button onClick={onClose} className="text-gray-500 hover:text-gray-700 text-2xl font-bold" aria-label="Fermer">×</button>
 					</div>

--- a/apps/web/src/components/AnimalDetailsModal.tsx
+++ b/apps/web/src/components/AnimalDetailsModal.tsx
@@ -19,6 +19,7 @@ interface AnimalDetailsModalProps {
 	isOpen: boolean;
 	onClose: () => void;
 	animal: AnimalDto | null;
+	onDeleted?: () => void;
 }
 
 function formatDate(dateStr: string): string {
@@ -44,7 +45,7 @@ function computeAge(birthdate?: string | null): string | null {
 	return months > 0 ? `${years} ans ${months} mois` : `${years} ans`;
 }
 
-export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsModalProps) {
+export function AnimalDetailsModal({ isOpen, onClose, animal, onDeleted }: AnimalDetailsModalProps) {
 	const [loading, setLoading] = useState(false);
 	const [error, setError] = useState<string | null>(null);
 	const [history, setHistory] = useState<AnimalHistoryDto | null>(null);
@@ -201,6 +202,7 @@ export function AnimalDetailsModal({ isOpen, onClose, animal }: AnimalDetailsMod
 								try {
 									setDeleting(true);
 									await animalsService.deleteAnimal(animal.id);
+									onDeleted?.();
 									onClose();
 								} catch (e) {
 									setError(e instanceof Error ? e.message : 'Erreur lors de la suppression');

--- a/apps/web/src/components/__tests__/AnimalDetailsModal.test.tsx
+++ b/apps/web/src/components/__tests__/AnimalDetailsModal.test.tsx
@@ -158,7 +158,7 @@ describe('AnimalDetailsModal', () => {
       expect(screen.getByText('Détails')).toBeInTheDocument();
     });
 
-    const deleteBtn = screen.getByRole('button', { name: "Supprimer" });
+    const deleteBtn = screen.getByRole('button', { name: "Supprimer l'animal" });
     fireEvent.click(deleteBtn);
 
     await waitFor(() => {

--- a/apps/web/src/components/__tests__/AnimalDetailsModal.test.tsx
+++ b/apps/web/src/components/__tests__/AnimalDetailsModal.test.tsx
@@ -11,6 +11,7 @@ vi.mock('../../services/animals.service', () => ({
   animalsService: {
     getHistory: vi.fn(),
     updateAnimal: vi.fn(),
+    deleteAnimal: vi.fn(),
   },
 }));
 
@@ -145,6 +146,26 @@ describe('AnimalDetailsModal', () => {
     await waitFor(() => {
       expect(mockAnimalsService.updateAnimal).toHaveBeenCalled();
     });
+  });
+
+  it('confirms and deletes the animal', async () => {
+    // Confirm dialog OK
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+
+    render(<AnimalDetailsModal {...defaultProps} />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Détails')).toBeInTheDocument();
+    });
+
+    const deleteBtn = screen.getByRole('button', { name: "Supprimer" });
+    fireEvent.click(deleteBtn);
+
+    await waitFor(() => {
+      expect(mockAnimalsService.deleteAnimal).toHaveBeenCalled();
+    });
+
+    confirmSpy.mockRestore();
   });
 
   it('does not render when closed', () => {

--- a/apps/web/src/pages/owner/OwnerAnimals.tsx
+++ b/apps/web/src/pages/owner/OwnerAnimals.tsx
@@ -107,6 +107,10 @@ export function OwnerAnimals() {
           isOpen={selectedAnimal != null}
           onClose={() => setSelectedAnimal(null)}
           animal={selectedAnimal}
+          onDeleted={() => {
+            setSelectedAnimal(null);
+            loadAnimals();
+          }}
         />
       </div>
     </div>

--- a/apps/web/src/services/__tests__/animals.service.test.ts
+++ b/apps/web/src/services/__tests__/animals.service.test.ts
@@ -7,6 +7,7 @@ vi.mock('../http.service', () => ({
     get: vi.fn(),
     post: vi.fn(),
     patch: vi.fn(),
+    delete: vi.fn(),
     download: vi.fn(),
   },
 }));

--- a/apps/web/src/services/__tests__/animals.service.test.ts
+++ b/apps/web/src/services/__tests__/animals.service.test.ts
@@ -22,6 +22,12 @@ describe('animalsService', () => {
     expect(httpService.patch).toHaveBeenCalledWith('/animals/an1', { name: 'New', weightKg: 12.3 });
     expect(res).toMatchObject({ id: 'an1', name: 'New' });
   });
+
+  it('deleteAnimal calls DELETE endpoint', async () => {
+    (httpService.delete as any).mockResolvedValue(undefined);
+    await animalsService.deleteAnimal('an1');
+    expect(httpService.delete).toHaveBeenCalledWith('/animals/an1');
+  });
 });
 
 

--- a/apps/web/src/services/animals.service.ts
+++ b/apps/web/src/services/animals.service.ts
@@ -79,6 +79,10 @@ class AnimalsService {
       dto
     );
   }
+
+  async deleteAnimal(animalId: string): Promise<void> {
+    await httpService.delete(`/animals/${encodeURIComponent(animalId)}`);
+  }
 }
 
 export const animalsService = new AnimalsService();


### PR DESCRIPTION
This pull request adds the ability for animal owners to delete their animals from both the backend API and the frontend web application. It introduces a new endpoint for deletion, ensures proper authorization and error handling, and updates the UI to allow users to perform this action, along with comprehensive tests for all changes.

**Backend API: Animal deletion feature**

* Added a new `DELETE /animals/:animalId` endpoint in `AnimalsController` that allows the owner of an animal to delete it, returning a 204 No Content response. This includes OpenAPI documentation and role-based access control. [[1]](diffhunk://#diff-b689f765687798164564e58ce130b78767074d650d6e85ebf16824c9dff7d72dR6-R11) [[2]](diffhunk://#diff-b689f765687798164564e58ce130b78767074d650d6e85ebf16824c9dff7d72dR223-R239)
* Implemented the `deleteAnimal` method in `AnimalsService`, which checks ownership, throws appropriate exceptions, and performs the deletion in a transaction for data consistency. [[1]](diffhunk://#diff-5111cc1e7678e09f50dbb8e2907fd85e95b78c07dd1f8285d323682f955c8db2R14) [[2]](diffhunk://#diff-5111cc1e7678e09f50dbb8e2907fd85e95b78c07dd1f8285d323682f955c8db2R27) [[3]](diffhunk://#diff-5111cc1e7678e09f50dbb8e2907fd85e95b78c07dd1f8285d323682f955c8db2R140-R155)
* Added and updated unit tests for both the controller and service to cover successful deletion, authorization checks, and error scenarios. [[1]](diffhunk://#diff-fcb3ff1680443c84b24f020d73262fb433f28ed24d6e827481b68f9760c6e8b9R18) [[2]](diffhunk://#diff-fcb3ff1680443c84b24f020d73262fb433f28ed24d6e827481b68f9760c6e8b9R125-R137) [[3]](diffhunk://#diff-2b1da15a0db2be9bfc0fff9e77f588bee5267d74fb6e01cd6ab9fdc722200edfR9) [[4]](diffhunk://#diff-2b1da15a0db2be9bfc0fff9e77f588bee5267d74fb6e01cd6ab9fdc722200edfR50-R61) [[5]](diffhunk://#diff-2b1da15a0db2be9bfc0fff9e77f588bee5267d74fb6e01cd6ab9fdc722200edfR208-R243)

**Frontend: UI and service integration**

* Updated the `AnimalDetailsModal` component to include a "Delete" button, handle confirmation, call the delete API, and trigger UI updates after deletion. [[1]](diffhunk://#diff-62a3f8040f589a07a0641bec63039b9910720becba0f04a8b49ac56e3c9fbecbR22) [[2]](diffhunk://#diff-62a3f8040f589a07a0641bec63039b9910720becba0f04a8b49ac56e3c9fbecbL47-R56) [[3]](diffhunk://#diff-62a3f8040f589a07a0641bec63039b9910720becba0f04a8b49ac56e3c9fbecbR196-R216) [[4]](diffhunk://#diff-929641cf866349ae5ca7776cd922db521a71f0c1d68dc567ff6a6a7ff48fed35R110-R113)
* Added the `deleteAnimal` method to the frontend `animalsService` and corresponding unit tests to ensure correct API calls. [[1]](diffhunk://#diff-c83477a7ed400a5d163c13b57435772e9b0f08d1619d8f499cc835affeefbea5R82-R85) [[2]](diffhunk://#diff-cb588b729b00332f276e836c05c697ccc02fb03a0f628871024a78780ecb30e2R10) [[3]](diffhunk://#diff-cb588b729b00332f276e836c05c697ccc02fb03a0f628871024a78780ecb30e2R26-R31)

**Database consistency**

* Updated the `ReminderInstance` entity to cascade deletes on related appointments, helping maintain referential integrity when animals are deleted.

**Frontend tests**

* Added tests to verify the delete button behavior and user confirmation flow in the modal component. [[1]](diffhunk://#diff-8499750f3d6ca696b4c55348f92771f48b0bb9b7d9dd46add5886d000dcceb22R14) [[2]](diffhunk://#diff-8499750f3d6ca696b4c55348f92771f48b0bb9b7d9dd46add5886d000dcceb22R151-R170)